### PR TITLE
feat(la0n): TIO-161: localization tool blocks

### DIFF
--- a/lib/l10n/app_localization.dart
+++ b/lib/l10n/app_localization.dart
@@ -114,6 +114,7 @@ abstract class AppLocalizations {
   String get metronomeNumberOfBeats;
   String get metronomeNumberOfPolyBeats;
   String get metronomeRandomMute;
+  String get metronomeRandomMuteChance;
   String get metronomeRandomMuteProbability;
   String get metronomeSetBpm;
   String get metronomeSetRandomMute;
@@ -122,6 +123,7 @@ abstract class AppLocalizations {
   String get metronomeSound;
   String get metronomeSoundMain;
   String get metronomeSoundPoly;
+  String get metronomeSoundPolyShort;
   String get metronomeSoundPrimary;
   String get metronomeSoundSecondary;
   String get metronomeTutorialAddNew;
@@ -130,6 +132,8 @@ abstract class AppLocalizations {
   String get metronomeTutorialRelocate;
   String get metronomeTutorialStartStop;
   String get metronomeUnaccented;
+
+  String metronomeSegment(int value);
 
   String get piano;
   String get pianoAbout;

--- a/lib/l10n/app_localization.dart
+++ b/lib/l10n/app_localization.dart
@@ -78,6 +78,7 @@ abstract class AppLocalizations {
   String get mediaPlayerFactorAndBpm;
   String get mediaPlayerFile;
   String get mediaPlayerLoadAudioFile;
+  String get mediaPlayerLooping;
   String get mediaPlayerMarkers;
   String get mediaPlayerOverwriteSound;
   String get mediaPlayerOverwriteSoundQuestion;

--- a/lib/l10n/de.dart
+++ b/lib/l10n/de.dart
@@ -92,6 +92,7 @@ class German extends AppLocalizations {
   String get mediaPlayerFactorAndBpm => 'Faktor und BPM Regler';
   String get mediaPlayerFile => 'Datei';
   String get mediaPlayerLoadAudioFile => 'Audio-Datei laden';
+  String get mediaPlayerLooping => 'Wiederholen';
   String get mediaPlayerMarkers => 'Marker';
   String get mediaPlayerOverwriteSound => 'Audio-Datei überschreiben';
   String get mediaPlayerOverwriteSoundQuestion => 'Möchtest du die Audio-Datei überschreiben?';

--- a/lib/l10n/de.dart
+++ b/lib/l10n/de.dart
@@ -131,6 +131,7 @@ class German extends AppLocalizations {
   String get metronomeNumberOfBeats => 'Anzahl der Beats';
   String get metronomeNumberOfPolyBeats => 'Anzahl der Poly-Beats';
   String get metronomeRandomMute => 'Zufälliges Stummschalten';
+  String get metronomeRandomMuteChance => 'Aussetzen';
   String get metronomeRandomMuteProbability => 'Wahrscheinlichkeit in %';
   String get metronomeSetBpm => 'BPM einstellen';
   String get metronomeSetRandomMute => 'Zufälliges Stummschalten einstellen';
@@ -138,7 +139,8 @@ class German extends AppLocalizations {
   String get metronomeSetSoundsSecondary => 'Klänge einstellen (Metronom 2)';
   String get metronomeSound => 'Klang';
   String get metronomeSoundMain => 'Hauptklang';
-  String get metronomeSoundPoly => 'Nebenklang';
+  String get metronomeSoundPoly => 'Poly-Klang';
+  String get metronomeSoundPolyShort => 'Nebenklang';
   String get metronomeSoundPrimary => 'Klang 1';
   String get metronomeSoundSecondary => 'Klang 2';
   String get metronomeTutorialAddNew => 'Tippe hier um ein zweites Metronom hinzuzufügen';
@@ -149,6 +151,8 @@ class German extends AppLocalizations {
       'Halte und ziehe seitlich um zu verschieben,\nstreiche nach oben um zu löschen\noder tippe um zu bearbeiten';
   String get metronomeTutorialStartStop => 'Tippe hier um das Metronom zu starten und zu stoppen';
   String get metronomeUnaccented => 'Unakzentuiert';
+
+  String metronomeSegment(int value) => '$value Segment${value == 1 ? '' : 'e'}';
 
   String get piano => 'Klavier';
   String get pianoAbout => 'Klavier';

--- a/lib/l10n/en.dart
+++ b/lib/l10n/en.dart
@@ -131,6 +131,7 @@ class English extends AppLocalizations {
   String get metronomeNumberOfBeats => 'Number of Beats';
   String get metronomeNumberOfPolyBeats => 'Number of Poly Beats';
   String get metronomeRandomMute => 'Random Mute';
+  String get metronomeRandomMuteChance => 'mute chance';
   String get metronomeRandomMuteProbability => 'Probability in %';
   String get metronomeSetBpm => 'Set BPM';
   String get metronomeSetRandomMute => 'Set Random Mute';
@@ -138,7 +139,8 @@ class English extends AppLocalizations {
   String get metronomeSetSoundsSecondary => 'Set 2nd Metronome Sounds';
   String get metronomeSound => 'Sound';
   String get metronomeSoundMain => 'Main';
-  String get metronomeSoundPoly => 'Poly';
+  String get metronomeSoundPoly => 'Poly-Sound';
+  String get metronomeSoundPolyShort => 'Poly';
   String get metronomeSoundPrimary => 'Sound 1';
   String get metronomeSoundSecondary => 'Sound 2';
   String get metronomeTutorialAddNew => 'Tap here to add a second metronome';
@@ -148,6 +150,8 @@ class English extends AppLocalizations {
       'Hold and drag sideways to relocate,\nswipe upwards to delete\nor tap to edit';
   String get metronomeTutorialStartStop => 'Tap here to start and stop the metronome';
   String get metronomeUnaccented => 'Unaccented';
+
+  String metronomeSegment(int value) => '$value segment${value == 1 ? '' : 's'}';
 
   String get piano => 'Piano';
   String get pianoAbout => 'Piano';

--- a/lib/l10n/en.dart
+++ b/lib/l10n/en.dart
@@ -92,6 +92,7 @@ class English extends AppLocalizations {
   String get mediaPlayerFactorAndBpm => 'Factor and BPM slider';
   String get mediaPlayerFile => 'File';
   String get mediaPlayerLoadAudioFile => 'Load Audio File';
+  String get mediaPlayerLooping => 'Looping';
   String get mediaPlayerMarkers => 'Markers';
   String get mediaPlayerOverwriteSound => 'Overwrite?';
   String get mediaPlayerOverwriteSoundQuestion =>

--- a/lib/models/blocks/media_player_block.dart
+++ b/lib/models/blocks/media_player_block.dart
@@ -145,20 +145,18 @@ class MediaPlayerBlock extends ProjectBlock {
       settings.add(FileIO.getFileName(_relativePath));
     }
     if (_pitchSemitones.abs() >= 0.01) {
-      settings.add(
-        "${_pitchSemitones > 0 ? "↑" : "↓"} ${_pitchSemitones.abs()} semitone${pluralSDouble(_pitchSemitones)}",
-      );
+      settings.add('${_pitchSemitones > 0 ? '↑' : '↓'} ${l10n.mediaPlayerSemitones(_pitchSemitones.round())}');
     }
     if (_speedFactor != 1) {
-      settings.add('${_speedFactor}x speed');
+      settings.add('${_speedFactor}x ${l10n.mediaPlayerSpeed}');
     }
     if (_rangeStart.abs() >= 0.001 || (_rangeEnd - 1.0).abs() >= 0.001) {
-      settings.add('Trim ${(_rangeStart * 100).round()}% → ${(_rangeEnd * 100).round()}%');
+      settings.add('${l10n.mediaPlayerTrim} ${(_rangeStart * 100).round()}% → ${(_rangeEnd * 100).round()}%');
     }
     if (_looping) {
-      settings.add('Looping');
+      settings.add(l10n.mediaPlayerLooping);
     }
-    settings.add('$bpm bpm');
+    settings.add('$bpm ${l10n.commonBpm}');
     return settings;
   }
 

--- a/lib/models/blocks/metronome_block.dart
+++ b/lib/models/blocks/metronome_block.dart
@@ -143,24 +143,24 @@ class MetronomeBlock extends ProjectBlock {
     }
 
     settings.addAll([
-      '${_rhythmGroups.length} segment${pluralSInt(_rhythmGroups.length)}',
-      'Sound: $accSound/$unaccSound',
-      'Poly-Sound: $polyAccSound/$polyUnaccSound',
+      l10n.metronomeSegment(_rhythmGroups.length),
+      '${l10n.metronomeSound}: $accSound/$unaccSound',
+      '${l10n.metronomeSoundPoly}: $polyAccSound/$polyUnaccSound',
     ]);
 
     if (_rhythmGroups2.isNotEmpty) {
       settings.addAll([
         '_____ 2 _____',
-        '${_rhythmGroups2.length} segment${pluralSInt(_rhythmGroups2.length)}',
-        'Sound: $accSound2/$unaccSound2',
-        'Poly-Sound: $polyAccSound2/$polyUnaccSound2',
+        l10n.metronomeSegment(_rhythmGroups2.length),
+        '${l10n.metronomeSound}: $accSound2/$unaccSound2',
+        '${l10n.metronomeSoundPoly}: $polyAccSound2/$polyUnaccSound2',
       ]);
     }
 
-    settings.addAll(['$bpm bpm', '$randomMute % random mute']);
+    settings.addAll(['$bpm ${l10n.commonBpm}']);
 
     if (randomMute > 0) {
-      settings.add('$randomMute% mute chance');
+      settings.add('$randomMute% ${l10n.metronomeRandomMuteChance}');
     }
 
     return settings;

--- a/lib/pages/metronome/metronome.dart
+++ b/lib/pages/metronome/metronome.dart
@@ -721,7 +721,7 @@ class _MetronomeState extends State<Metronome> with RouteAware {
         SettingsTile(
           title: _metronomeBlock.rhythmGroups2.isEmpty ? l10n.metronomeSound : l10n.metronomeSoundPrimary,
           subtitle:
-              '${l10n.metronomeSoundMain}: ${_metronomeBlock.accSound}, ${_metronomeBlock.unaccSound}\n${l10n.metronomeSoundPoly}: ${_metronomeBlock.polyAccSound}, ${_metronomeBlock.polyUnaccSound}',
+              '${l10n.metronomeSoundMain}: ${_metronomeBlock.accSound}, ${_metronomeBlock.unaccSound}\n${l10n.metronomeSoundPolyShort}: ${_metronomeBlock.polyAccSound}, ${_metronomeBlock.polyUnaccSound}',
           leadingIcon: Icons.library_music_outlined,
           settingPage: SetMetronomeSound(running: _sound && _isStarted),
           block: _metronomeBlock,
@@ -733,7 +733,7 @@ class _MetronomeState extends State<Metronome> with RouteAware {
           SettingsTile(
             title: l10n.metronomeSoundSecondary,
             subtitle:
-                '${l10n.metronomeSoundMain}: ${_metronomeBlock.accSound2}, ${_metronomeBlock.unaccSound2}\n${l10n.metronomeSoundPoly}: ${_metronomeBlock.polyAccSound2}, ${_metronomeBlock.polyUnaccSound2}',
+                '${l10n.metronomeSoundMain}: ${_metronomeBlock.accSound2}, ${_metronomeBlock.unaccSound2}\n${l10n.metronomeSoundPolyShort}: ${_metronomeBlock.polyAccSound2}, ${_metronomeBlock.polyUnaccSound2}',
             leadingIcon: Icons.library_music_outlined,
             settingPage: SetMetronomeSound(running: _sound && _isStarted, forSecondMetronome: true),
             block: _metronomeBlock,

--- a/lib/util/util_functions.dart
+++ b/lib/util/util_functions.dart
@@ -532,14 +532,6 @@ String formatDoubleToString(double value) {
   }
 }
 
-String pluralSDouble(double number) {
-  return (number.abs() - 1.0).abs() < 0.001 ? '' : 's';
-}
-
-String pluralSInt(int number) {
-  return (number - 1).abs() == 0 ? '' : 's';
-}
-
 bool checkIslandPossible(Project? project, ProjectBlock toolBlock) {
   if (project != null) {
     // if we are in a normal tool, check the following


### PR DESCRIPTION
**Are there specific parts that the reviewer should look out for?**

- [ ] no
- [x] yes (please specify)

In ```metronome_block.dart```, the chance of random mute was shown twice when higher than 0%. This is old, and no new issue we've implemented. I guess the setting was added twice by mistake in the past, so I've deleted it.

**Any other comments?** _(e.g., unrelated minor changes piggybacking this PR)_

- [x] no
- [ ] yes (please specify)

**Helpful screenshots?**

- [ ] no
- [x] yes

<img width="485" alt="image" src="https://github.com/user-attachments/assets/561edc1f-4935-4cb8-8300-15e36542cff5" />

