### PR TITLE
fix: TIO-86: use latest semantic version when commit has multiple tags

### DIFF
--- a/scripts/load-version-from-latest-tag.sh
+++ b/scripts/load-version-from-latest-tag.sh
@@ -13,8 +13,8 @@ if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 fi
 
 set +e
-SEMVER_TAG=$(git tag --list '[0-9]*.[0-9]*.[0-9]**' --sort=-creatordate | head -n1)
-BUILD_NUMBER_TAG=$(git tag --list '[0-9]*.[0-9]*.[0-9]*+*' --sort=-creatordate | head -n1)
+SEMVER_TAG=$(git tag --list '[0-9]*.[0-9]*.[0-9]**' | sort -V | tail -n1)
+BUILD_NUMBER_TAG=$(git tag --list '[0-9]*.[0-9]*.[0-9]*+*' | sort -V | tail -n1)
 set -e
 
 if [ -z "$SEMVER_TAG" ]; then


### PR DESCRIPTION
**Are there specific parts that the reviewer should look out for?**

- [x] no
- [ ] yes (please specify)

**Any other comments?** _(e.g., unrelated minor changes piggybacking this PR)_

- [x] no
- [ ] yes (please specify)

**Helpful screenshots?**

- [x] no
- [ ] yes
