### PR TITLE
fix: TIO-139: support cancelling of keys

### DIFF
--- a/lib/widgets/piano/black_key.dart
+++ b/lib/widgets/piano/black_key.dart
@@ -14,8 +14,6 @@ class BlackKey extends StatelessWidget {
   final double borderWidth;
   final String semanticsLabel;
 
-  final Function() onPlay;
-
   const BlackKey({
     super.key,
     required this.isPlayed,
@@ -23,7 +21,6 @@ class BlackKey extends StatelessWidget {
     required this.height,
     required this.borderWidth,
     required this.semanticsLabel,
-    required this.onPlay,
   });
 
   @override
@@ -46,7 +43,6 @@ class BlackKey extends StatelessWidget {
               excludeFromSemantics: true,
               splashColor: _playedColor,
               highlightColor: _playedColor,
-              onTapDown: (_) => onPlay(),
               child: Ink(
                 decoration: BoxDecoration(
                   color: color,

--- a/lib/widgets/piano/white_key.dart
+++ b/lib/widgets/piano/white_key.dart
@@ -12,8 +12,6 @@ class WhiteKey extends StatelessWidget {
   final String semanticsLabel;
   final String? label;
 
-  final Function() onPlay;
-
   const WhiteKey({
     super.key,
     required this.isPlayed,
@@ -22,7 +20,6 @@ class WhiteKey extends StatelessWidget {
     required this.borderWidth,
     required this.semanticsLabel,
     this.label,
-    required this.onPlay,
   });
 
   @override
@@ -42,7 +39,6 @@ class WhiteKey extends StatelessWidget {
               excludeFromSemantics: true,
               splashColor: _playedColor,
               highlightColor: _playedColor,
-              onTapDown: (_) => onPlay(),
               child: Align(
                 alignment: Alignment.bottomCenter,
                 child:

--- a/test/widgets/piano/keyboard_black_keys_test.dart
+++ b/test/widgets/piano/keyboard_black_keys_test.dart
@@ -8,7 +8,7 @@ void main() {
       testWidgets('renders no sharp on first half of first white key', (tester) async {
         final pianoMock = await tester.renderKeyboard();
 
-        await tester.pressAndReleaseBlackKeyAt(5);
+        await tester.pressAndReleaseBlackKeyAt(4);
         pianoMock.verifyKeyPlayed(c4);
       });
 
@@ -125,7 +125,7 @@ void main() {
       testWidgets('renders no sharp on first half of first white key', (tester) async {
         final pianoMock = await tester.renderKeyboard(d4);
 
-        await tester.pressAndReleaseBlackKeyAt(5);
+        await tester.pressAndReleaseBlackKeyAt(4);
         pianoMock.verifyKeyPlayed(d4);
       });
 
@@ -211,7 +211,7 @@ void main() {
       testWidgets('renders no sharp on first half of first white key', (tester) async {
         final pianoMock = await tester.renderKeyboard(f4);
 
-        await tester.pressAndReleaseBlackKeyAt(5);
+        await tester.pressAndReleaseBlackKeyAt(4);
         pianoMock.verifyKeyPlayed(f4);
       });
 

--- a/test/widgets/piano/keyboard_playing_keys_test.dart
+++ b/test/widgets/piano/keyboard_playing_keys_test.dart
@@ -177,5 +177,26 @@ void main() {
         pianoMock.verifyNoKeysPlayed();
       });
     });
+
+    group('playing more keys than supported', () {
+      testWidgets('cancels keys', (tester) async {
+        final pianoMock = await tester.renderKeyboard();
+
+        final gesture1 = await tester.startGesture(blackKey1);
+        final gesture2 = await tester.startGesture(blackKey2);
+
+        pianoMock.verifyKeyPlayed(cSharp4);
+        pianoMock.verifyKeyPlayed(dSharp4);
+
+        await gesture1.cancel();
+        await gesture2.cancel();
+
+        pianoMock.verifyKeyReleased(cSharp4);
+        pianoMock.verifyKeyReleased(dSharp4);
+
+        pianoMock.verifyNoKeysReleased();
+        pianoMock.verifyNoKeysPlayed();
+      });
+    });
   });
 }


### PR DESCRIPTION
**Are there specific parts that the reviewer should look out for?**

- [ ] no
- [x] yes (please specify)

- adds handling of pointer cancel events (when more fingers than supported are pressed all fingers are cancelled by the OS)
- replaces tracking of pressed keys in favor of handling pointer down events
- removes tap events from black and white keys

**Any other comments?** _(e.g., unrelated minor changes piggybacking this PR)_

- [x] no
- [ ] yes (please specify)

**Helpful screenshots?**

- [x] no
- [ ] yes
