### PR TITLE
fix: TIO-122: limit image upload on Android

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,8 +24,17 @@ import 'package:tiomusic/services/impl/file_system_impl.dart';
 import 'package:tiomusic/services/media_repository.dart';
 import 'package:tiomusic/services/project_repository.dart';
 import 'package:tiomusic/splash_app.dart';
+import 'package:image_picker_platform_interface/image_picker_platform_interface.dart';
+import 'package:image_picker_android/image_picker_android.dart';
 
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  final platform = ImagePickerPlatform.instance;
+  if (platform is ImagePickerAndroid) {
+    platform.useAndroidPhotoPicker = true;
+  }
+
   runApp(
     MultiProvider(
       providers: _getProviders(),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -589,7 +589,7 @@ packages:
     source: hosted
     version: "1.1.2"
   image_picker_android:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_android
       sha256: "317a5d961cec5b34e777b9252393f2afbd23084aa6e60fcf601dcf6341b9ebeb"
@@ -629,13 +629,13 @@ packages:
     source: hosted
     version: "0.2.1+2"
   image_picker_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: image_picker_platform_interface
-      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.1"
+    version: "2.10.0"
   image_picker_windows:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -632,10 +632,10 @@ packages:
     dependency: "direct main"
     description:
       name: image_picker_platform_interface
-      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.10.1"
   image_picker_windows:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   flutter_svg: 2.1.0
   frontend_server_client: 4.0.0
   image_picker: 1.1.2
+  image_picker_android: 0.8.12+23  # TODO: Delete when image_picker has fixes limit for images on Android
+  image_picker_platform_interface: 2.10.0  # TODO: Delete when image_picker has fixes limit for images on Android
   intl: 0.19.0  # TODO: upgrade as soon as flutter_localizations supports it
   json_annotation: 4.9.0
   logger: 2.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,8 +26,8 @@ dependencies:
   flutter_svg: 2.1.0
   frontend_server_client: 4.0.0
   image_picker: 1.1.2
-  image_picker_android: 0.8.12+23  # TODO: Delete when image_picker has fixes limit for images on Android
-  image_picker_platform_interface: 2.10.1  # TODO: Delete when image_picker has fixes limit for images on Android
+  image_picker_android: 0.8.12+23  # TODO: Delete when image_picker fixed limit for images on Android
+  image_picker_platform_interface: 2.10.1  # TODO: Delete when image_picker fixed limit for images on Android
   intl: 0.19.0  # TODO: upgrade as soon as flutter_localizations supports it
   json_annotation: 4.9.0
   logger: 2.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   frontend_server_client: 4.0.0
   image_picker: 1.1.2
   image_picker_android: 0.8.12+23  # TODO: Delete when image_picker has fixes limit for images on Android
-  image_picker_platform_interface: 2.10.0  # TODO: Delete when image_picker has fixes limit for images on Android
+  image_picker_platform_interface: 2.10.1  # TODO: Delete when image_picker has fixes limit for images on Android
   intl: 0.19.0  # TODO: upgrade as soon as flutter_localizations supports it
   json_annotation: 4.9.0
   logger: 2.5.0

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -569,10 +569,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
+      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.0"
+    version: "2.10.1"
   image_picker_windows:
     dependency: transitive
     description:

--- a/widgetbook/pubspec.lock
+++ b/widgetbook/pubspec.lock
@@ -569,10 +569,10 @@ packages:
     dependency: transitive
     description:
       name: image_picker_platform_interface
-      sha256: "886d57f0be73c4b140004e78b9f28a8914a09e50c2d816bdd0520051a71236a0"
+      sha256: "9ec26d410ff46f483c5519c29c02ef0e02e13a543f882b152d4bfd2f06802f80"
       url: "https://pub.dev"
     source: hosted
-    version: "2.10.1"
+    version: "2.10.0"
   image_picker_windows:
     dependency: transitive
     description:


### PR DESCRIPTION
**Are there specific parts that the reviewer should look out for?**

- [x] no
- [ ] yes (please specify)

**Any other comments?** _(e.g., unrelated minor changes piggybacking this PR)_

- [ ] no
- [x] yes (please specify)

The not-working limit on Android is a known issue (https://github.com/flutter/flutter/issues/147773?utm_source=chatgpt.com) since May 2025. It was documented, but not fixed yet. The ticket on GitHub was closed automatically at the beginning of June, and the current version of file_picker is 12 months old. A fix may come soon.

I found a workaround to limit the images on Android (see `main.dart` and installed dependencies) and left a TODO to check regularly if we can get rid of the additional setup.

**We now have the following support:**

- Android 13 (API 33) and above
Fully supports the new Photo Picker with multi-selection and enforced limits (e.g., pickMultiImage(limit: 5)).

- Android 12 (API 31–32)
No native multi-select Photo Picker. The system picker only supports single-image selection and ignores limit.

- Android 11 (API 30) and below
No Photo Picker at all—fallback to legacy ACTION_OPEN_DOCUMENT, which does not support limit enforcement

**Note:** Our current `minSdkVersion` is 31. Android version 12 and API version 32 do not get security updates for 3 months! (https://endoflife.date/android)

**Helpful screenshots?**

- [ ] no
- [x] yes

**Limit on Android:**
<img width="386" alt="image" src="https://github.com/user-attachments/assets/619b02c3-e7d4-45e7-8223-e00a2d80c538" />
